### PR TITLE
Refactor publish-to-pypi.yml to use new custom steps

### DIFF
--- a/workflow-templates/publish-to-pypi.yml
+++ b/workflow-templates/publish-to-pypi.yml
@@ -5,22 +5,35 @@ on:
     types: [released]
 
 jobs:
-  build:
-      name: Publish release to PyPI
-      env:
-        PYPI_USERNAME_STSCI_MAINTAINER: ${{ secrets.PYPI_USERNAME_STSCI_MAINTAINER }}
-        PYPI_PASSWORD_STSCI_MAINTAINER: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }}
-        PYPI_USERNAME_OVERRIDE: ${{ secrets.PYPI_USERNAME_OVERRIDE }}
-        PYPI_PASSWORD_OVERRIDE: ${{ secrets.PYPI_PASSWORD_OVERRIDE }}
-        PYPI_TEST: ${{ secrets.PYPI_TEST }}
-        INDEX_URL_OVERRIDE: ${{ secrets.INDEX_URL_OVERRIDE }}
-      runs-on: ubuntu-latest
-      steps:
+  validate:
+    name: Validate metadata
+    runs-on: ubuntu-latest
+    steps:
+      - uses: spacetelescope/action-publish_to_pypi/validate@master
 
-          # Check out the commit containing this workflow file.
-          - name: checkout repo
-            uses: actions/checkout@v2
-         
-          - name: custom action
-            uses: spacetelescope/action-publish_to_pypi@master
-            id: custom_action_0
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-10.15]
+
+    steps:
+      - uses: spacetelescope/action-publish_to_pypi/build-wheel@master
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: spacetelescope/action-publish_to_pypi/build-sdist@master
+
+  upload_pypi:
+    needs: [validate, build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: spacetelescope/action-publish_to_pypi/publish@master
+        with:
+          test: ${{ secrets.PYPI_TEST }}
+          user: ${{ secrets.PYPI_USERNAME_STSCI_MAINTAINER }}
+          password: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }}
+          test_password: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER_TEST }}


### PR DESCRIPTION
This change switches the workflow template to use the new steps introduced in https://github.com/spacetelescope/action-publish_to_pypi/pull/14.

This will not be ready to merge until logic is added to the `build-wheel` step to automatically build a pure-Python wheel. Currently the step errors out if a platform wheel is not necessary, making this change backwards-incompatible for repositories without C extensions.

This change also removes the use of the `PYPI_USERNAME_OVERRIDE` and `PYPI_PASSWORD_OVERRIDE` secrets, since overriding `PYPI_USERNAME_STSCI_MAINTAINER` and `PYPI_PASSWORD_STSCI_MAINTAINER` in an individual repository is sufficient to override the values provided by the `spacetelescope` organization, although it does make them inaccurately named now. If we would prefer not to remove this functionality, please let me know and I will amend the custom steps accordingly.

It also removes references to the `INDEX_URL_OVERRIDE` secret, which is ignored by the current custom step anyway.